### PR TITLE
feat: add optional sign check to isInteger validator

### DIFF
--- a/modules/validators.js
+++ b/modules/validators.js
@@ -94,17 +94,35 @@ export function isDate() {
   return _isdate;
 };
 
-export function isInteger() {
+export function isInteger(signed) {
   /**
-   * Returns function that determines if a value is an integer or not.
-   * @param {any} val the value from the configured field.
-   * @returns (function} the validation function.
+   * Returns a validation function that checks whether a value is an integer and,
+   * optionally, whether it meets the specified sign constraint.
+   *
+   * @param {any} val - The value to validate.
+   * @param {object} schema - (Unused; kept for signature consistency.)
+   * @param {string} prop_name - The property name used for error messages.
+   * @returns {number} The validated integer if it meets all criteria.
+   * @throws {Error} If the value is not an integer or does not satisfy the sign constraint.
    */
   function _isinteger(val, schema, prop_name) {
     if (typeof val === 'number' && !isNaN(val) && val % 1 === 0) {
+      // If a sign constraint is specified, perform an additional check.
+      if (typeof signed === 'boolean') {
+        if (signed === false && val < 0) {
+          // When signed is false, only positive integers (and zero) are allowed.
+          throw makeSchemaError(
+            prop_name + ': "' + val + '" is not a positive integer.'
+          );
+        } else if (signed === true && val >= 0) {
+          // When signed is true, only negative integers are allowed.
+          throw makeSchemaError(
+            prop_name + ': "' + val + '" is not a negative integer.'
+          );
+        }
+      }
       return val;
-    }
-    else {
+    } else {
       throw makeSchemaError(
         prop_name + ': "' + val + '" is not an integer.'
       );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voluptjs",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voluptjs",
-      "version": "0.0.9",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^9.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voluptjs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A work-a-like javascript clone of python voluptuous (https://pypi.org/project/voluptuous)",
   "type": "module",
   "main": "index.js",

--- a/test/unit/test-validators.js
+++ b/test/unit/test-validators.js
@@ -68,8 +68,7 @@ test('Test validators.isNumber', async (t) =>{
 
 });
 
-test('Test validators.isInteger', async (t) =>{
-
+test('Test validators.isInteger', async (t) => {
   let sut;
   t.before(() => {
     sut = new Schema([
@@ -77,17 +76,59 @@ test('Test validators.isInteger', async (t) =>{
     ]);
   });
 
-  await t.test('valid', () => {
-    const expectation = {danumber: 123};
+  // Default behavior (no sign constraint)
+  await t.test('default valid', () => {
+    const expectation = { danumber: 123 };
     assert.deepStrictEqual(sut.validate(expectation), expectation);
   });
 
-  await t.test('invalid', () => {
+  await t.test('default invalid', () => {
     const expectation = new Error('danumber: "123.45" is not an integer.');
     expectation.isSchemaError = true;
-    assert.throws(() => sut.validate({danumber: 123.45}), expectation);
+    assert.throws(() => sut.validate({ danumber: 123.45 }), expectation);
   });
 
+  // Tests for positive integer constraint (signed === false)
+  await t.test('valid positive integer with signed false', () => {
+    let positiveSchema = new Schema([
+      [Required('danumber'), isInteger(false)]
+    ]);
+    // 0 and positive integers should pass
+    const expectation1 = { danumber: 0 };
+    const expectation2 = { danumber: 123 };
+    assert.deepStrictEqual(positiveSchema.validate(expectation1), expectation1);
+    assert.deepStrictEqual(positiveSchema.validate(expectation2), expectation2);
+  });
+
+  await t.test('invalid positive integer with signed false', () => {
+    let positiveSchema = new Schema([
+      [Required('danumber'), isInteger(false)]
+    ]);
+    // Negative integer should fail
+    const expectation = new Error('danumber: "-123" is not a positive integer.');
+    expectation.isSchemaError = true;
+    assert.throws(() => positiveSchema.validate({ danumber: -123 }), expectation);
+  });
+
+  // Tests for negative integer constraint (signed === true)
+  await t.test('valid negative integer with signed true', () => {
+    let negativeSchema = new Schema([
+      [Required('danumber'), isInteger(true)]
+    ]);
+    // Negative integer should pass
+    const expectation = { danumber: -456 };
+    assert.deepStrictEqual(negativeSchema.validate(expectation), expectation);
+  });
+
+  await t.test('invalid negative integer with signed true', () => {
+    let negativeSchema = new Schema([
+      [Required('danumber'), isInteger(true)]
+    ]);
+    // Positive integer should fail
+    const expectation = new Error('danumber: "789" is not a negative integer.');
+    expectation.isSchemaError = true;
+    assert.throws(() => negativeSchema.validate({ danumber: 789 }), expectation);
+  });
 });
 
 test('Test validators.isString', async (t) =>{


### PR DESCRIPTION
This PR adds an optional signed parameter to the isInteger validator function. With this enhancement, users can now specify a sign constraint:

Default (no parameter): Validates any integer (both positive and negative).
isInteger(false): Validates only positive integers (and zero).
isInteger(true): Validates only negative integers.